### PR TITLE
Publish artifact on a new tag

### DIFF
--- a/.github/workflows/publish-artifact.yaml
+++ b/.github/workflows/publish-artifact.yaml
@@ -2,9 +2,8 @@ name: Artifact publish
 
 on:
   push:
-    branches: [master]
-    paths-ignore:
-      - '*.md'
+    tags:
+      - "v*.*.*"
 
 jobs:
   publish:


### PR DESCRIPTION
Publishing on merge is error prone and with multiple PRs can break proper versioning.