### PR TITLE
Added a method to aggressively release resources used by OkHttp.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.traveltime</groupId>
     <artifactId>traveltime-sdk-java</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
 
     <distributionManagement>
         <repository>

--- a/src/main/java/com/traveltime/sdk/TravelTimeSDK.java
+++ b/src/main/java/com/traveltime/sdk/TravelTimeSDK.java
@@ -248,12 +248,5 @@ public class TravelTimeSDK {
     public void close() {
         client.dispatcher().executorService().shutdown();
         client.connectionPool().evictAll();
-        try {
-            if (client.cache() != null) {
-                client.cache().close();
-            }
-        } catch (IOException ignored) {
-
-        }
     }
 }

--- a/src/main/java/com/traveltime/sdk/TravelTimeSDK.java
+++ b/src/main/java/com/traveltime/sdk/TravelTimeSDK.java
@@ -243,4 +243,17 @@ public class TravelTimeSDK {
 
         return future;
     }
+
+    /** Only useful for applications that need to aggressively clean up resources, as this is done automatically by OkHttp. */
+    public void close() {
+        client.dispatcher().executorService().shutdown();
+        client.connectionPool().evictAll();
+        try {
+            if (client.cache() != null) {
+                client.cache().close();
+            }
+        } catch (IOException ignored) {
+
+        }
+    }
 }


### PR DESCRIPTION
Using this method in benchmarks:
```
    @TearDown(Level.Iteration)
    public void tearDown() {
        sdk.close();
    }

    @Setup(Level.Iteration)
    public void setUpIteration() {
        sdk = TravelTimeSDK.builder().baseProtoUri(URI.create("http://proto.api.traveltimeapp.com/api/v2/")).credentials(credentials).build();
    }
```
should prevent wait times between iterations, where jmh hangs for 30 seconds before forcing forked VMs to exit. 