### PR TITLE
Add @Singular annotation to all list fields in request dtos

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ ArrivalSearch arrivalSearch = ArrivalSearch
 Union union = Union
     .builder()
     .id("Union of driving and public transport")
-    .searchIds(Arrays.asList("Public transport from Trafalgar Square", "Driving from Trafalgar Square"))
+    .searchId("Public transport from Trafalgar Square")
+    .searchId("Driving from Trafalgar Square")
     .build();
 
 Intersection intersection = Intersection
@@ -86,9 +87,9 @@ Intersection intersection = Intersection
 TimeMapRequest request = TimeMapRequest
     .builder()
     .departureSearches(Arrays.asList(departureSearch1, departureSearch2))
-    .arrivalSearches(Collections.singletonList(arrivalSearch))
-    .unions(Collections.singletonList(union))
-    .intersections(Collections.singletonList(intersection))
+    .arrivalSearch(arrivalSearch)
+    .union(union)
+    .intersection(intersection)
     .build();
 
 Either<TravelTimeError, TimeMapResponse> response = sdk.send(request);
@@ -146,8 +147,8 @@ ArrivalSearch arrivalSearch = ArrivalSearch
 TimeFilterRequest request = TimeFilterRequest
     .builder()
     .locations(locations)
-    .arrivalSearches(Collections.singletonList(arrivalSearch))
-    .departureSearches(Collections.singletonList(departureSearch))
+    .arrivalSearch(arrivalSearch)
+    .departureSearch(departureSearch)
     .build();
     
 Either<TravelTimeError, TimeFilterResponse> response = sdk.send(request);   
@@ -200,8 +201,8 @@ ArrivalSearch arrivalSearch = ArrivalSearch
 RoutesRequest request = RoutesRequest
     .builder()
     .locations(locations)
-    .departureSearches(Collections.singletonList(departureSearch))
-    .arrivalSearches(Collections.singletonList(arrivalSearch))
+    .arrivalSearch(arrivalSearch)
+    .departureSearch(departureSearch)
     .build();
     
 Either<TravelTimeError, RoutesResponse> response = sdk.send(request);

--- a/src/main/java/com/traveltime/sdk/dto/requests/GeocodingRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/GeocodingRequest.java
@@ -21,6 +21,7 @@ public class GeocodingRequest extends TravelTimeRequest<GeocodingResponse> {
     @NonNull
     String query;
 
+    @Singular
     List<String> withinCountries;
 
     Integer limit;

--- a/src/main/java/com/traveltime/sdk/dto/requests/ReverseGeocodingRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/ReverseGeocodingRequest.java
@@ -20,6 +20,7 @@ import java.util.List;
 public class ReverseGeocodingRequest extends TravelTimeRequest<GeocodingResponse> {
     @NonNull Coordinates coordinates;
 
+    @Singular
     List<String> withinCountries;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/RoutesRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/RoutesRequest.java
@@ -26,10 +26,13 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RoutesRequest extends TravelTimeRequest<RoutesResponse> {
     @NonNull
+    @Singular
     List<Location> locations;
     @Valid
+    @Singular
     List<DepartureSearch> departureSearches;
     @Valid
+    @Singular
     List<ArrivalSearch> arrivalSearches;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/SupportedLocationsRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/SupportedLocationsRequest.java
@@ -22,6 +22,7 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class SupportedLocationsRequest extends TravelTimeRequest<SupportedLocationsResponse> {
     @NonNull
+    @Singular
     List<Location> locations;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterDistrictsRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterDistrictsRequest.java
@@ -20,7 +20,9 @@ import java.util.List;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class TimeFilterDistrictsRequest extends TravelTimeRequest<TimeFilterDistrictsResponse> {
+    @Singular
     List<DepartureSearch> departureSearches;
+    @Singular
     List<ArrivalSearch> arrivalSearches;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterFastProtoDistanceRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterFastProtoDistanceRequest.java
@@ -30,6 +30,7 @@ public class TimeFilterFastProtoDistanceRequest extends ProtoRequest<TimeFilterF
     @NonNull
     Coordinates originCoordinate;
     @NonNull
+    @Singular
     List<Coordinates> destinationCoordinates;
     @NonNull
     Country country;

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterFastRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterFastRequest.java
@@ -22,6 +22,7 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class TimeFilterFastRequest extends TravelTimeRequest<TimeFilterFastResponse> {
     @NonNull
+    @Singular
     List<Location> locations;
     @NonNull
     ArrivalSearches arrivalSearches;

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterPostcodesRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterPostcodesRequest.java
@@ -22,8 +22,10 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class TimeFilterPostcodesRequest extends TravelTimeRequest<TimeFilterPostcodesResponse> {
     @Valid
+    @Singular
     List<DepartureSearch> departureSearches;
     @Valid
+    @Singular
     List<ArrivalSearch> arrivalSearches;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterRequest.java
@@ -26,10 +26,13 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TimeFilterRequest extends TravelTimeRequest<TimeFilterResponse> {
     @NonNull
+    @Singular
     List<Location> locations;
     @Valid
+    @Singular
     List<DepartureSearch> departureSearches;
     @Valid
+    @Singular
     List<ArrivalSearch> arrivalSearches;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterSectorsRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeFilterSectorsRequest.java
@@ -20,7 +20,9 @@ import java.util.List;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class TimeFilterSectorsRequest extends TravelTimeRequest<TimeFilterSectorsResponse> {
+    @Singular
     List<DepartureSearch> departureSearches;
+    @Singular
     List<ArrivalSearch> arrivalSearches;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeMapBoxesRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeMapBoxesRequest.java
@@ -27,12 +27,16 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TimeMapBoxesRequest  extends TravelTimeRequest<TimeMapBoxesResponse> {
     @Valid
+    @Singular
     List<DepartureSearch> departureSearches;
     @Valid
+    @Singular
     List<ArrivalSearch> arrivalSearches;
 
+    @Singular
     List<Intersection> intersections;
 
+    @Singular
     List<Union> unions;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeMapGeoJsonRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeMapGeoJsonRequest.java
@@ -27,12 +27,16 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TimeMapGeoJsonRequest extends TravelTimeRequest<TimeMapGeoJsonResponse> {
     @Valid
+    @Singular
     List<DepartureSearch> departureSearches;
     @Valid
+    @Singular
     List<ArrivalSearch> arrivalSearches;
 
+    @Singular
     List<Intersection> intersections;
 
+    @Singular
     List<Union> unions;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeMapKmlRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeMapKmlRequest.java
@@ -27,12 +27,16 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TimeMapKmlRequest extends TravelTimeRequest<Kml>{
     @Valid
+    @Singular
     List<DepartureSearch> departureSearches;
     @Valid
+    @Singular
     List<ArrivalSearch> arrivalSearches;
 
+    @Singular
     List<Intersection> intersections;
 
+    @Singular
     List<Union> unions;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeMapRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeMapRequest.java
@@ -27,12 +27,16 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TimeMapRequest extends TravelTimeRequest<TimeMapResponse> {
     @Valid
+    @Singular
     List<DepartureSearch> departureSearches;
     @Valid
+    @Singular
     List<ArrivalSearch> arrivalSearches;
 
+    @Singular
     List<Intersection> intersections;
 
+    @Singular
     List<Union> unions;
 
     @Override

--- a/src/main/java/com/traveltime/sdk/dto/requests/TimeMapWktRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TimeMapWktRequest.java
@@ -27,12 +27,16 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TimeMapWktRequest extends TravelTimeRequest<TimeMapWktResponse> {
     @Valid
+    @Singular
     List<DepartureSearch> departureSearches;
     @Valid
+    @Singular
     List<ArrivalSearch> arrivalSearches;
 
+    @Singular
     List<Intersection> intersections;
 
+    @Singular
     List<Union> unions;
 
     @Builder.Default

--- a/src/main/java/com/traveltime/sdk/dto/requests/postcodes/ArrivalSearch.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/postcodes/ArrivalSearch.java
@@ -32,6 +32,7 @@ public class ArrivalSearch {
     @Positive(message = "travelTime should be positive")
     Integer travelTime;
     @NonNull
+    @Singular
     List<Property> properties;
     @Valid
     FullRange range;

--- a/src/main/java/com/traveltime/sdk/dto/requests/postcodes/DepartureSearch.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/postcodes/DepartureSearch.java
@@ -32,6 +32,7 @@ public class DepartureSearch {
     @Positive(message = "travelTime should be positive")
     Integer travelTime;
     @NonNull
+    @Singular
     List<Property> properties;
     @Valid
     FullRange range;

--- a/src/main/java/com/traveltime/sdk/dto/requests/proto/OneToMany.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/proto/OneToMany.java
@@ -14,6 +14,7 @@ public class OneToMany {
     @NonNull
     Coordinates originCoordinate;
     @NonNull
+    @Singular
     List<Coordinates> destinationCoordinates;
     @NonNull
     Transportation transportation;

--- a/src/main/java/com/traveltime/sdk/dto/requests/routes/ArrivalSearch.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/routes/ArrivalSearch.java
@@ -20,6 +20,7 @@ public class ArrivalSearch {
     @NonNull
     String id;
     @NonNull
+    @Singular
     List<String> departureLocationIds;
     @NonNull
     String arrivalLocationId;
@@ -28,6 +29,7 @@ public class ArrivalSearch {
     @NonNull
     Instant arrivalTime;
     @NonNull
+    @Singular
     List<Property> properties;
     @Valid
     FullRange range;

--- a/src/main/java/com/traveltime/sdk/dto/requests/routes/DepartureSearch.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/routes/DepartureSearch.java
@@ -22,12 +22,14 @@ public class DepartureSearch {
     @NonNull
     String departureLocationId;
     @NonNull
+    @Singular
     List<String> arrivalLocationIds;
     @NonNull
     Transportation transportation;
     @NonNull
     Instant departureTime;
     @NonNull
+    @Singular
     List<Property> properties;
     @Valid
     FullRange range;

--- a/src/main/java/com/traveltime/sdk/dto/requests/timefilter/ArrivalSearch.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/timefilter/ArrivalSearch.java
@@ -21,6 +21,7 @@ public class ArrivalSearch {
     @NonNull
     String id;
     @NonNull
+    @Singular
     List<String> departureLocationIds;
     @NonNull
     String arrivalLocationId;

--- a/src/main/java/com/traveltime/sdk/dto/requests/timefilter/DepartureSearch.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/timefilter/DepartureSearch.java
@@ -23,6 +23,7 @@ public class DepartureSearch {
     @NonNull
     String departureLocationId;
     @NonNull
+    @Singular
     List<String> arrivalLocationIds;
     @NonNull
     Transportation transportation;
@@ -32,6 +33,7 @@ public class DepartureSearch {
     @Positive(message = "travelTime must be greater than 0")
     Integer travelTime;
     @NonNull
+    @Singular
     List<Property> properties;
     @Valid
     FullRange range;

--- a/src/main/java/com/traveltime/sdk/dto/requests/timefilterfast/ManyToOne.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/timefilterfast/ManyToOne.java
@@ -16,6 +16,7 @@ public class ManyToOne {
     @NonNull
     String arrivalLocationId;
     @NonNull
+    @Singular
     List<String> departureLocationIds;
     @NonNull
     Transportation transportation;
@@ -24,5 +25,6 @@ public class ManyToOne {
     @NonNull
     String arrivalTimePeriod;
     @NonNull
+    @Singular
     List<Property> properties;
 }

--- a/src/main/java/com/traveltime/sdk/dto/requests/timefilterfast/OneToMany.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/timefilterfast/OneToMany.java
@@ -16,6 +16,7 @@ public class OneToMany {
     @NonNull
     String departureLocationId;
     @NonNull
+    @Singular
     List<String> arrivalLocationIds;
     @NonNull
     Transportation transportation;
@@ -24,5 +25,6 @@ public class OneToMany {
     @NonNull
     String arrivalTimePeriod;
     @NonNull
+    @Singular
     List<Property> properties;
 }

--- a/src/main/java/com/traveltime/sdk/dto/requests/timemap/Intersection.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/timemap/Intersection.java
@@ -13,5 +13,6 @@ public class Intersection {
     @NonNull
     String id;
     @NonNull
+    @Singular
     List<String> searchIds;
 }

--- a/src/main/java/com/traveltime/sdk/dto/requests/timemap/Union.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/timemap/Union.java
@@ -13,5 +13,6 @@ public class Union {
     @NonNull
     String id;
     @NonNull
+    @Singular
     List<String> searchIds;
 }

--- a/src/main/java/com/traveltime/sdk/dto/requests/zones/ArrivalSearch.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/zones/ArrivalSearch.java
@@ -32,6 +32,7 @@ public class ArrivalSearch {
     @NonNull
     Double reachablePostcodesThreshold;
     @NonNull
+    @Singular
     List<Property> properties;
     @Valid
     FullRange range;

--- a/src/main/java/com/traveltime/sdk/dto/requests/zones/DepartureSearch.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/zones/DepartureSearch.java
@@ -32,6 +32,7 @@ public class DepartureSearch {
     @NonNull
     Double reachablePostcodesThreshold;
     @NonNull
+    @Singular
     List<Property> properties;
     @Valid
     FullRange range;

--- a/src/test/resources/dto/requests/timeMapRequest.json
+++ b/src/test/resources/dto/requests/timeMapRequest.json
@@ -26,5 +26,7 @@
       "enabled" : true,
       "width" : 3600
     }
-  } ]
+  } ],
+  "intersections" : [ ],
+  "unions" : [ ]
 }


### PR DESCRIPTION
Allows us to use
```
builder.property(x)
```
instead of
```
builder.properties(new List<>(x))
```
Technically a breaking change since previously a call to `properties` overrode the previously set properties, not it's essentially an `addAll` call. To reset the user would have to call `clearProperties`. I guess this means if merged we would have to increment a major version.

Soliciting ideas for singular names for
```
public class ArrivalSearches {
    @NonNull
    List<ManyToOne> manyToOne;
    @NonNull
    List<OneToMany> oneToMany;
}
```