### PR TITLE
add user agent headers

### DIFF
--- a/src/main/java/com/traveltime/sdk/dto/requests/ProtoRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/ProtoRequest.java
@@ -43,6 +43,7 @@ public abstract class ProtoRequest<T> {
             .url(url)
             .headers(credentials.getBasicCredentialsHeaders())
             .addHeader("Content-Type", AcceptType.APPLICATION_OCTET_STREAM.getValue())
+            .addHeader("User-Agent", "Travel Time Java SDK")
             .post(RequestBody.create(requestBody))
             .build();
     }

--- a/src/main/java/com/traveltime/sdk/dto/requests/TravelTimeRequest.java
+++ b/src/main/java/com/traveltime/sdk/dto/requests/TravelTimeRequest.java
@@ -32,6 +32,7 @@ public abstract class TravelTimeRequest<T> {
         return new Request.Builder()
             .url(url)
             .headers(credentials.getHeaders())
+            .addHeader("User-Agent", "Travel Time Java SDK")
             .get()
             .build();
     }
@@ -46,6 +47,7 @@ public abstract class TravelTimeRequest<T> {
             .url(url)
             .headers(credentials.getHeaders())
             .addHeader("Accept", acceptType.getValue())
+            .addHeader("User-Agent", "Travel Time Java SDK")
             .post(RequestBody.create(jsonString, JSON))
             .build();
     }


### PR DESCRIPTION
as requested by ops last month. @danielnaumau this could also be added to the headers on Credentials class, however I did not feel that to be correct so just added everywhere explicitly. Please advise if you would do this differently.