### PR TITLE
Bump okhttp and jakarta.el versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.3</version>
+            <version>4.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>de.grundid.opendatalab</groupId>


### PR DESCRIPTION
I was seeing the following warnings from dependency-check-maven (using `mvn org.owasp:dependency-check-maven:8.1.2:aggregate -DfailBuildOnCVSS=1 verify` ):
```
One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '1.0': 

jakarta.el-4.0.1.jar: CVE-2021-28170(7.5)
kotlin-stdlib-1.4.10.jar: CVE-2020-29582(5.3), CVE-2022-24329(5.3)
kotlin-stdlib-common-1.4.0.jar: CVE-2020-29582(5.3), CVE-2020-15824(8.8), CVE-2022-24329(5.3)
```
I'm hestiant to use this in production environments with these present.

Bumping okhttp and jakarta.el to their latest release versions, as per this pull request, just leaves:
```
One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '1.0': 

kotlin-stdlib-jdk7-1.5.31.jar: CVE-2022-24329(5.3)
```
Bumping okhttp to `5.0.0-alpha.11` would remove that warning too.

Thanks.