### PR TITLE
TravelTimeError: add retrieveCause() with optional return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,25 @@ TravelTimeSDK sdk = TravelTimeSDK
   .build();
 ```
 
+## Development
+
+We use Maven as a build automation tool in this project.
+
+To run unit tests you can execute:
+
+```shell
+mvn test
+```
+
+Please note that you will need to export some valid credentials as environment variables in your shell to make tests work:
+
+```shell
+export APP_ID="..."
+export API_KEY="..."
+export PROTO_USERNAME="..."
+export PROTO_PASSWORD="..."
+```
+
 ## Support
 
 If you have problems, please write an issue or contact us by writing to support@traveltime.com

--- a/src/main/java/com/traveltime/sdk/dto/responses/errors/IOError.java
+++ b/src/main/java/com/traveltime/sdk/dto/responses/errors/IOError.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 
+import io.vavr.control.Option;
+
 @Getter
 @AllArgsConstructor
 public class IOError implements TravelTimeError {
@@ -13,6 +15,9 @@ public class IOError implements TravelTimeError {
 
     @NonNull
     String errorMessage;
+
+    @Override
+    public Option<Throwable> retrieveCause() { return Option.of(cause); }
 
     @Override
     public String getMessage() {

--- a/src/main/java/com/traveltime/sdk/dto/responses/errors/JsonProcessingError.java
+++ b/src/main/java/com/traveltime/sdk/dto/responses/errors/JsonProcessingError.java
@@ -1,5 +1,6 @@
 package com.traveltime.sdk.dto.responses.errors;
 
+import io.vavr.control.Option;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
@@ -9,6 +10,9 @@ import lombok.ToString;
 public class JsonProcessingError implements TravelTimeError {
     @NonNull
     String errorMsg;
+
+    @Override
+    public Option<Throwable> retrieveCause() { return Option.none(); }
 
     @Override
     public String getMessage() {

--- a/src/main/java/com/traveltime/sdk/dto/responses/errors/ProtoError.java
+++ b/src/main/java/com/traveltime/sdk/dto/responses/errors/ProtoError.java
@@ -1,5 +1,6 @@
 package com.traveltime.sdk.dto.responses.errors;
 
+import io.vavr.control.Option;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
@@ -9,6 +10,9 @@ import lombok.ToString;
 public class ProtoError implements TravelTimeError {
     @NonNull
     String errorMsg;
+
+    @Override
+    public Option<Throwable> retrieveCause() { return Option.none(); }
 
     @Override
     public String getMessage() {

--- a/src/main/java/com/traveltime/sdk/dto/responses/errors/RequestError.java
+++ b/src/main/java/com/traveltime/sdk/dto/responses/errors/RequestError.java
@@ -1,5 +1,6 @@
 package com.traveltime.sdk.dto.responses.errors;
 
+import io.vavr.control.Option;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
@@ -9,6 +10,9 @@ import lombok.ToString;
 public class RequestError implements TravelTimeError {
     @NonNull
     String errorMsg;
+
+    @Override
+    public Option<Throwable> retrieveCause() { return Option.none(); }
 
     @Override
     public String getMessage() {

--- a/src/main/java/com/traveltime/sdk/dto/responses/errors/ResponseError.java
+++ b/src/main/java/com/traveltime/sdk/dto/responses/errors/ResponseError.java
@@ -1,6 +1,7 @@
 package com.traveltime.sdk.dto.responses.errors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.vavr.control.Option;
 import lombok.*;
 import lombok.extern.jackson.Jacksonized;
 
@@ -24,6 +25,10 @@ public class ResponseError implements TravelTimeError {
     String documentationLink;
     @NonNull
     Map<String, List<String>> additionalInfo;
+
+    @Override
+    @JsonIgnore
+    public Option<Throwable> retrieveCause() { return Option.none(); }
 
     @Override
     @JsonIgnore

--- a/src/main/java/com/traveltime/sdk/dto/responses/errors/TravelTimeError.java
+++ b/src/main/java/com/traveltime/sdk/dto/responses/errors/TravelTimeError.java
@@ -1,5 +1,8 @@
 package com.traveltime.sdk.dto.responses.errors;
 
+import io.vavr.control.Option;
+
 public interface TravelTimeError {
+    Option<Throwable> retrieveCause();
     String getMessage();
 }

--- a/src/main/java/com/traveltime/sdk/dto/responses/errors/ValidationError.java
+++ b/src/main/java/com/traveltime/sdk/dto/responses/errors/ValidationError.java
@@ -1,5 +1,6 @@
 package com.traveltime.sdk.dto.responses.errors;
 
+import io.vavr.control.Option;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
@@ -9,6 +10,9 @@ import lombok.ToString;
 public class ValidationError implements TravelTimeError {
     @NonNull
     String errorMsg;
+
+    @Override
+    public Option<Throwable> retrieveCause() { return Option.none(); }
 
     @Override
     public String getMessage() {

--- a/src/main/java/com/traveltime/sdk/dto/responses/errors/XmlError.java
+++ b/src/main/java/com/traveltime/sdk/dto/responses/errors/XmlError.java
@@ -1,5 +1,6 @@
 package com.traveltime.sdk.dto.responses.errors;
 
+import io.vavr.control.Option;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
@@ -11,6 +12,9 @@ import lombok.ToString;
 public class XmlError implements TravelTimeError {
     @NonNull
     Throwable cause;
+
+    @Override
+    public Option<Throwable> retrieveCause() { return Option.of(cause); }
 
     @Override
     public String getMessage() {

--- a/src/test/java/com/traveltime/sdk/ErrorTest.java
+++ b/src/test/java/com/traveltime/sdk/ErrorTest.java
@@ -1,0 +1,57 @@
+package com.traveltime.sdk;
+
+import com.traveltime.sdk.auth.TravelTimeCredentials;
+import com.traveltime.sdk.dto.requests.MapInfoRequest;
+import com.traveltime.sdk.dto.responses.MapInfoResponse;
+import com.traveltime.sdk.dto.responses.errors.IOError;
+import com.traveltime.sdk.dto.responses.errors.ResponseError;
+import com.traveltime.sdk.dto.responses.errors.TravelTimeError;
+import com.traveltime.sdk.dto.responses.errors.XmlError;
+import io.vavr.control.Either;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class ErrorTest {
+    TravelTimeSDK sdk;
+
+    @Before
+    public void init() {
+        TravelTimeCredentials credentials = new TravelTimeCredentials(
+            "wrong-api-id-does-not-exist-123456789",
+            "wrong-api-key-12345678"
+        );
+        sdk = new TravelTimeSDK(credentials);
+    }
+
+    @Test
+    public void shouldDetectErrorForWrongCredentials() {
+        MapInfoRequest request = new MapInfoRequest();
+        Either<TravelTimeError, MapInfoResponse> response = sdk.send(request);
+        Assert.assertTrue(response.isLeft());
+        Assert.assertTrue(response.getLeft() instanceof ResponseError);
+        ResponseError responseError = (ResponseError) response.getLeft();
+        Assert.assertEquals(7, (int) responseError.getErrorCode());
+        Assert.assertEquals(401, (int) responseError.getHttpStatus());
+        Assert.assertTrue(responseError.retrieveCause().isEmpty());
+    }
+
+    @Test
+    public void shouldRetrieveCauseForIOError() {
+        String message = "Booom";
+        Throwable cause = new IllegalStateException(message);
+        IOError ioError = new IOError(cause, "some error occurred");
+        Assert.assertFalse(ioError.retrieveCause().isEmpty());
+        Assert.assertSame(message, ioError.retrieveCause().get().getMessage());
+    }
+
+    @Test
+    public void shouldRetrieveCauseForXmlError() {
+        String message = "Booom";
+        Throwable cause = new IllegalStateException(message);
+        XmlError xmlError = new XmlError(cause);
+        Assert.assertFalse(xmlError.retrieveCause().isEmpty());
+        Assert.assertSame(message, xmlError.retrieveCause().get().getMessage());
+    }
+}


### PR DESCRIPTION
This exposes the causes that e.g. IOError detects. This can be useful for users to show more detailed errors in their applications.

IOError and XmlError support returning the cause.
Other subclasses return Option.none().

Added ErrorTest to check whether Error classes are properly implemented. Checking wrong credentials (ResponseError) and explicitly setting up IOError and XmlError objects to check the retrieved exceptions.

Extended documentation for how to set up testing.