### PR TITLE
CI: disable persist-credentials for actions/checkout

### DIFF
--- a/.github/workflows/publish-artifact.yaml
+++ b/.github/workflows/publish-artifact.yaml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
 
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1


### PR DESCRIPTION
It is a possible security issue.
We do not want to persist credentials in the repo and thus exposing those to further steps.

Also upgraded actions/checkout version.

References:

* https://github.com/actions/checkout/issues/485#issuecomment-1197047674
* https://github.com/azat/chdig/pull/67